### PR TITLE
Add localization (English + Spanish), donate link, and release version check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          MANIFEST_VERSION=$(grep '"version"' manifest.json | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          MANIFEST_VERSION=$(jq -r '.version' manifest.json)
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: manifest=$MANIFEST_VERSION, tag=$TAG_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           zip -r extension.zip \
             manifest.json \
+            _locales/ \
             popup/ \
             content-scripts/ \
             data/ \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify version matches tag
+        run: |
+          MANIFEST_VERSION=$(grep '"version"' manifest.json | sed 's/.*"version": *"\([^"]*\)".*/\1/')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: manifest=$MANIFEST_VERSION, tag=$TAG_VERSION"
+            exit 1
+          fi
+          echo "Version check passed: $MANIFEST_VERSION"
+
       - name: Build extension zip
         run: |
           zip -r extension.zip \

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -13,5 +13,6 @@
   "toastNoEmails":        { "message": "No emails found" },
   "toastSingular":        { "message": "$1 email masked" },
   "toastPlural":          { "message": "$1 emails masked" },
-  "donateLink":           { "message": "Buy me a coffee ☕" }
+  "donateLink":           { "message": "Buy me a coffee ☕" },
+  "previewName":          { "message": "alice" }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,17 @@
+{
+  "appName":              { "message": "Maskify" },
+  "appDescription":       { "message": "An extension that helps you protect user privacy by replacing email addresses with fake ones." },
+  "popupTitle":           { "message": "Maskify" },
+  "popupDescription":     { "message": "Replace all email addresses on this page with masked addresses." },
+  "labelDomain":          { "message": "Domain" },
+  "labelAddNumber":       { "message": "Add number (e.g. alice<strong>7</strong>)" },
+  "labelAddLastInitial":  { "message": "Add last initial (e.g. alice<strong>_r</strong>)" },
+  "labelShowAsterisk":    { "message": "Mark replacements with ***" },
+  "labelPreview":         { "message": "Preview" },
+  "buttonMask":           { "message": "Mask Emails" },
+  "toastTitle":           { "message": "Maskify" },
+  "toastNoEmails":        { "message": "No emails found" },
+  "toastSingular":        { "message": "$1 email masked" },
+  "toastPlural":          { "message": "$1 emails masked" },
+  "donateLink":           { "message": "Buy me a coffee ☕" }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -13,5 +13,6 @@
   "toastNoEmails":        { "message": "No se encontraron correos" },
   "toastSingular":        { "message": "$1 correo enmascarado" },
   "toastPlural":          { "message": "$1 correos enmascarados" },
-  "donateLink":           { "message": "Cómprame un café ☕" }
+  "donateLink":           { "message": "Cómprame un café ☕" },
+  "previewName":          { "message": "alicia" }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,17 @@
+{
+  "appName":              { "message": "Maskify" },
+  "appDescription":       { "message": "Una extensión que te ayuda a proteger la privacidad del usuario reemplazando direcciones de correo electrónico con direcciones falsas." },
+  "popupTitle":           { "message": "Maskify" },
+  "popupDescription":     { "message": "Reemplaza todas las direcciones de correo electrónico en esta página con direcciones enmascaradas." },
+  "labelDomain":          { "message": "Dominio" },
+  "labelAddNumber":       { "message": "Agregar número (ej. alicia<strong>7</strong>)" },
+  "labelAddLastInitial":  { "message": "Agregar inicial del apellido (ej. alicia<strong>_r</strong>)" },
+  "labelShowAsterisk":    { "message": "Marcar reemplazos con ***" },
+  "labelPreview":         { "message": "Vista previa" },
+  "buttonMask":           { "message": "Enmascarar correos" },
+  "toastTitle":           { "message": "Maskify" },
+  "toastNoEmails":        { "message": "No se encontraron correos" },
+  "toastSingular":        { "message": "$1 correo enmascarado" },
+  "toastPlural":          { "message": "$1 correos enmascarados" },
+  "donateLink":           { "message": "Cómprame un café ☕" }
+}

--- a/content-scripts/content.js
+++ b/content-scripts/content.js
@@ -4,7 +4,15 @@ const MASKIFY_NAMES_BY_LOCALE = {
   en: MASKIFY_NAMES_EN,
   es: MASKIFY_NAMES_ES,
 };
-const _lang = (navigator.language || 'en').split('-')[0].toLowerCase();
+const _uiLanguage = (
+  (typeof chrome !== 'undefined' &&
+    chrome.i18n &&
+    typeof chrome.i18n.getUILanguage === 'function' &&
+    chrome.i18n.getUILanguage()) ||
+  navigator.language ||
+  'en'
+);
+const _lang = _uiLanguage.split('-')[0].toLowerCase();
 const MASKIFY_NAMES = MASKIFY_NAMES_BY_LOCALE[_lang] || MASKIFY_NAMES_EN;
 
 const replacements = new Set();

--- a/content-scripts/content.js
+++ b/content-scripts/content.js
@@ -77,7 +77,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const textBlock = document.createElement('div');
 
     const title = document.createElement('div');
-    title.textContent = 'Maskify';
+    title.textContent = chrome.i18n.getMessage('toastTitle');
     Object.assign(title.style, {
       fontSize: '10px',
       fontWeight: '600',
@@ -89,9 +89,14 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     });
 
     const label = document.createElement('div');
-    label.textContent = count === 0
-      ? 'No emails found'
-      : `${count} email${count === 1 ? '' : 's'} masked`;
+    if (count === 0) {
+      label.textContent = chrome.i18n.getMessage('toastNoEmails');
+    } else {
+      label.textContent = chrome.i18n.getMessage(
+        count === 1 ? 'toastSingular' : 'toastPlural',
+        [String(count)]
+      );
+    }
 
     textBlock.appendChild(title);
     textBlock.appendChild(label);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_appName__",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "manifest_version": 3,
     "default_locale": "en",
     "description": "__MSG_appDescription__",

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
-    "name": "Maskify",
+    "name": "__MSG_appName__",
     "version": "1.1.0",
     "manifest_version": 3,
-    "description": "An extension that helps you protect user privacy by replacing email addresses with fake ones.",
+    "default_locale": "en",
+    "description": "__MSG_appDescription__",
     "permissions": ["tabs", "storage"],
     "icons": {
       "16": "icons/maskify16x16.png",

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -107,7 +107,7 @@
       text-align: center;
       font-size: 11px;
       color: #595959;
-      text-decoration: underline;
+      text-decoration: none;
     }
 
     .donate-link:hover { color: #333; }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -101,6 +101,17 @@
     button:hover  { background: #106ebe; }
     button:active { background: #005a9e; }
 
+    .donate-link {
+      display: block;
+      margin-top: 10px;
+      text-align: center;
+      font-size: 11px;
+      color: #aaa;
+      text-decoration: none;
+    }
+
+    .donate-link:hover { color: #666; }
+
     .preview {
       display: flex;
       align-items: center;
@@ -130,37 +141,38 @@
 <body>
   <div class="header">
     <img src="../icons/maskify32x32.png" alt="" />
-    <h1>Maskify</h1>
+    <h1 id="popupTitle">Maskify</h1>
   </div>
   <div class="body">
-    <p class="description">Replace all email addresses on this page with masked addresses.</p>
+    <p id="popupDescription" class="description">Replace all email addresses on this page with masked addresses.</p>
     <div class="field">
-      <label class="field-label" for="domainInput">Domain</label>
+      <label id="labelDomain" class="field-label" for="domainInput">Domain</label>
       <input type="text" id="domainInput" class="domain-input" placeholder="example.com" />
     </div>
     <div class="field">
       <label class="checkbox-label">
         <input type="checkbox" id="addNumber" />
-        <span>Add number (e.g. alice<strong>7</strong>)</span>
+        <span id="labelAddNumber">Add number (e.g. alice<strong>7</strong>)</span>
       </label>
     </div>
     <div class="field">
       <label class="checkbox-label">
         <input type="checkbox" id="addLastInitial" />
-        <span>Add last initial (e.g. alice<strong>_r</strong>)</span>
+        <span id="labelAddLastInitial">Add last initial (e.g. alice<strong>_r</strong>)</span>
       </label>
     </div>
     <div class="field">
       <label class="checkbox-label">
         <input type="checkbox" id="showAsterisk" />
-        <span>Mark replacements with ***</span>
+        <span id="labelShowAsterisk">Mark replacements with ***</span>
       </label>
     </div>
     <div class="preview">
-      <span class="preview-label">Preview</span>
+      <span id="labelPreview" class="preview-label">Preview</span>
       <code id="previewAddress"></code>
     </div>
     <button id="sendmessageid">Mask Emails</button>
+    <a id="donateLink" class="donate-link" href="https://donate.stripe.com/3cIeVd8iSbCo2VGeKxenS01" target="_blank" rel="noopener noreferrer">Buy me a coffee ☕</a>
   </div>
   <script src="../data/domain-utils.js"></script>
   <script src="popup.js"></script>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -106,11 +106,11 @@
       margin-top: 10px;
       text-align: center;
       font-size: 11px;
-      color: #aaa;
-      text-decoration: none;
+      color: #595959;
+      text-decoration: underline;
     }
 
-    .donate-link:hover { color: #666; }
+    .donate-link:hover { color: #333; }
 
     .preview {
       display: flex;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', function () {
     domainInput.classList.toggle('invalid', invalid);
     const domain = raw && !invalid ? raw.toLowerCase() : 'example.com';
     const marker = showAsteriskInput.checked ? '***' : '';
-    let localPart = 'alice';
+    let localPart = chrome.i18n.getMessage('previewName');
     if (addLastInitialInput.checked) localPart += '_r';
     if (addNumberInput.checked) localPart += '7';
     previewAddress.textContent = `${localPart}${marker}@${domain}`;

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,14 @@
 document.addEventListener('DOMContentLoaded', function () {
+  document.getElementById('popupTitle').textContent        = chrome.i18n.getMessage('popupTitle');
+  document.getElementById('popupDescription').textContent  = chrome.i18n.getMessage('popupDescription');
+  document.getElementById('labelDomain').textContent       = chrome.i18n.getMessage('labelDomain');
+  document.getElementById('labelAddNumber').innerHTML      = chrome.i18n.getMessage('labelAddNumber');
+  document.getElementById('labelAddLastInitial').innerHTML = chrome.i18n.getMessage('labelAddLastInitial');
+  document.getElementById('labelShowAsterisk').textContent = chrome.i18n.getMessage('labelShowAsterisk');
+  document.getElementById('labelPreview').textContent      = chrome.i18n.getMessage('labelPreview');
+  document.getElementById('sendmessageid').textContent     = chrome.i18n.getMessage('buttonMask');
+  document.getElementById('donateLink').textContent        = chrome.i18n.getMessage('donateLink');
+
   const domainInput = document.getElementById('domainInput');
   const addNumberInput = document.getElementById('addNumber');
   const addLastInitialInput = document.getElementById('addLastInitial');


### PR DESCRIPTION
## Summary

- Adds MV3 i18n support with `_locales/en/` and `_locales/es/` so the Edge store recognizes Spanish as a supported language
- All popup UI strings and toast notifications are now localized via `chrome.i18n.getMessage()`
- Adds a subtle "Buy me a coffee ☕" donate link to the popup (Stripe), styled to meet WCAG AA contrast requirements
- Adds `_locales/` to the publish workflow zip so localization files are included in the store artifact
- Switches manifest version extraction in the publish workflow from `grep`/`sed` to `jq` for robustness
- Adds a version-match check to the publish workflow — fails the release if the manifest version doesn't match the git tag

## Test plan

- [ ] Reload extension in English — popup labels unchanged
- [ ] Launch Edge with `--lang=es` — popup shows "Dominio", "Vista previa", "Enmascarar correos", etc.
- [ ] Toast shows correct localized count string after masking
- [ ] Donate link opens Stripe in a new tab
- [ ] Create a release with a mismatched tag — verify the workflow fails on the version check step