### PR TITLE
Mask emails in textarea values and placeholders

### DIFF
--- a/content-scripts/content.js
+++ b/content-scripts/content.js
@@ -69,6 +69,11 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       if (input.value) input.value = replace(input.value);
       if (input.placeholder) input.placeholder = replace(input.placeholder);
     });
+
+    document.querySelectorAll('textarea').forEach(textarea => {
+      if (textarea.value) textarea.value = replace(textarea.value);
+      if (textarea.placeholder) textarea.placeholder = replace(textarea.placeholder);
+    });
   }
 
   function showToast(count) {


### PR DESCRIPTION
## Summary

- Adds a `textarea` pass to `replaceEmailAddresses()` in `content-scripts/content.js`, mirroring the existing `input` pass
- Replaces both `.value` and `.placeholder` on each textarea
- Testpage section 7 covers this scenario

## Test plan

- Open `testpage.html` after reloading the extension
- Click Mask Emails
- Confirm both email addresses in the textarea body are replaced
- Confirm the behavior matches the existing input field scenario in section 6

Closes part of #6