### PR TITLE
Show donation link after 2 masking runs

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -102,7 +102,7 @@
     button:active { background: #005a9e; }
 
     .donate-link {
-      display: block;
+      display: none;
       margin-top: 10px;
       text-align: center;
       font-size: 11px;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -110,6 +110,8 @@
       text-decoration: none;
     }
 
+    .donate-link.visible { display: block; }
+
     .donate-link:hover { color: #333; }
 
     .preview {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
     addLastInitialInput.checked = data.addLastInitial;
     showAsteriskInput.checked = data.showAsterisk;
     maskCount = data.maskCount;
-    if (maskCount >= 2) document.getElementById('donateLink').style.display = 'block';
+    if (maskCount >= 2) document.getElementById('donateLink').classList.add('visible');
     updatePreview();
   });
 
@@ -54,10 +54,13 @@ document.addEventListener('DOMContentLoaded', function () {
       const addLastInitial = addLastInitialInput.checked;
       const showAsterisk = showAsteriskInput.checked;
 
-      chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk, maskCount: maskCount + 1 });
+      chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk });
 
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         chrome.tabs.sendMessage(tabs[0].id, { domain, addNumber, addLastInitial, showAsterisk }, function () {
+          if (!chrome.runtime.lastError) {
+            chrome.storage.sync.set({ maskCount: maskCount + 1 });
+          }
           window.close();
         });
       });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -54,13 +54,10 @@ document.addEventListener('DOMContentLoaded', function () {
       const addLastInitial = addLastInitialInput.checked;
       const showAsterisk = showAsteriskInput.checked;
 
-      chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk });
-
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         chrome.tabs.sendMessage(tabs[0].id, { domain, addNumber, addLastInitial, showAsterisk }, function () {
-          if (!chrome.runtime.lastError) {
-            chrome.storage.sync.set({ maskCount: maskCount + 1 });
-          }
+          const newCount = !chrome.runtime.lastError ? maskCount + 1 : maskCount;
+          chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk, maskCount: newCount });
           window.close();
         });
       });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -32,11 +32,15 @@ document.addEventListener('DOMContentLoaded', function () {
   addLastInitialInput.addEventListener('change', updatePreview);
   showAsteriskInput.addEventListener('change', updatePreview);
 
-  chrome.storage.sync.get({ domain: '', addNumber: true, addLastInitial: false, showAsterisk: true }, function (data) {
+  let maskCount = 0;
+
+  chrome.storage.sync.get({ domain: '', addNumber: true, addLastInitial: false, showAsterisk: true, maskCount: 0 }, function (data) {
     domainInput.value = data.domain;
     addNumberInput.checked = data.addNumber;
     addLastInitialInput.checked = data.addLastInitial;
     showAsteriskInput.checked = data.showAsterisk;
+    maskCount = data.maskCount;
+    if (maskCount >= 2) document.getElementById('donateLink').style.display = 'block';
     updatePreview();
   });
 
@@ -50,7 +54,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const addLastInitial = addLastInitialInput.checked;
       const showAsterisk = showAsteriskInput.checked;
 
-      chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk });
+      chrome.storage.sync.set({ domain: storedDomain, addNumber, addLastInitial, showAsterisk, maskCount: maskCount + 1 });
 
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         chrome.tabs.sendMessage(tabs[0].id, { domain, addNumber, addLastInitial, showAsterisk }, function () {


### PR DESCRIPTION
## Summary

- Donation link is now hidden by default and only appears once the user
  has clicked "Mask Emails" at least twice (across sessions and restarts)
- Count is stored in `chrome.storage.sync` alongside existing settings,
  so it persists through browser restarts and syncs across devices

## Why

New users should get a chance to confirm the extension works before
seeing the prompt. Two runs is enough to know it does what it says.

## Changes

- `popup/popup.html`: `.donate-link` default display changed to `none`
- `popup/popup.js`: reads `maskCount` from storage on load, shows the
  link when count reaches 2, and increments the count on each button click

## Testing

1. Clear extension storage (DevTools > Application > Storage > Clear site data)
2. Open popup: donation link not visible
3. Click "Mask Emails", reopen popup: still hidden
4. Click "Mask Emails" again, reopen popup: link appears
5. Close and reopen browser, reopen popup: link stays visible