### PR TITLE
Add Maskify favicon to GitHub Pages hosted pages

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Maskify — Privacy Policy</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="icons/maskify32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="icons/maskify16x16.png">
   <style>
     body { font-family: sans-serif; max-width: 680px; margin: 3rem auto; padding: 0 1rem; line-height: 1.6; color: #222; }
     h1 { font-size: 1.5rem; }

--- a/testpage.html
+++ b/testpage.html
@@ -2,6 +2,8 @@
 <html>
 <head>
   <title>Maskify Test Page</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="icons/maskify32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="icons/maskify16x16.png">
   <style>
     body { font-family: sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
     h2 { margin-top: 2rem; border-bottom: 1px solid #ccc; padding-bottom: 0.25rem; }


### PR DESCRIPTION
## Summary

- Adds `<link rel="icon">` tags to `testpage.html` and `privacy.html`
- Uses the existing `icons/maskify32x32.png` and `icons/maskify16x16.png` assets already in the repo
- Applies to both GitHub Pages hosted pages (test page and privacy policy)

## Testing

Open either page on GitHub Pages and confirm the Maskify shield icon appears in the browser tab.